### PR TITLE
Upgrade smoltcp to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,9 +215,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "managed"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75de51135344a4f8ed3cfe2720dc27736f7711989703a0b43aadf3753c55577"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "memchr"
@@ -435,9 +435,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "smoltcp"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4a069bef843d170df47e7c0a8bf8d037f217d9f5b325865acc3e466ffe40d3"
+checksum = "d2308a1657c8db1f5b4993bab4e620bdbe5623bd81f254cf60326767bb243237"
 dependencies = [
  "bitflags",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ void = { version = "1.0.2", default-features = false }
 
 hal = { package="esp32c3-hal", git = "https://github.com/esp-rs/esp-hal", rev = "02c5f4564b0fca1321b18e98e66e124a0b276643", features = [ "normalboot" ] }
 riscv-rt = { version = "0.8.1" }
-smoltcp = { version = "0.7.3", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "ethernet", "proto-dhcpv4", "socket-raw"] }
+smoltcp = { version = "0.8.0", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
 critical-section = "0.2.5"
 
 [build-dependencies]


### PR DESCRIPTION
0.8.0 includes a [tonne of fixes](https://github.com/smoltcp-rs/smoltcp/blob/master/CHANGELOG.md#080---2021-12-11), as well as improved DHCPv4 "client" (its now a socket). Won't change much here, but best to get the breaking changes out of the way before we started add more chip support.